### PR TITLE
Fix font import

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -4,7 +4,7 @@ Screenshot : http://pappu687.github.io/screenshots/adminer-screenshot.png
 Based on work by : Lukáš Brandejs	
 https://raw.github.com/vrana/adminer/master/designs/ng9/adminer.css
 */
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata);
+@import url(//fonts.googleapis.com/css?family=Roboto:400,700|Inconsolata);
 
 
 * {


### PR DESCRIPTION
By not specifying a protocol, it will follow whatever protocol the page is being accessed with, allowing it to load over https if the adminer page is accessed over https.

Fixes issue #8